### PR TITLE
Add platform to tini download

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:focal-20210119
 ARG MINIFORGE_NAME=Miniforge3
 ARG MINIFORGE_VERSION=4.9.2-5
 ARG TINI_VERSION=v0.18.0
+ARG TARGETPLATFORM
 
 ENV CONDA_DIR=/opt/conda
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
@@ -25,7 +26,8 @@ RUN apt-get update > /dev/null && \
         git > /dev/null && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    wget --no-hsts --quiet https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$(cut -d / -f 2 <<< ${TARGETPLATFORM}) -O /usr/local/bin/tini && \
+    TARGETARCH="$(echo ${TARGETPLATFORM} | cut -d / -f 2)"; case ${TARGETARCH} in "ppc64le") TARGETARCH="ppc64el" ;; *) ;; esac ; \
+    wget --no-hsts --quiet https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} -O /usr/local/bin/tini && \
     chmod +x /usr/local/bin/tini && \
     wget --no-hsts --quiet https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/${MINIFORGE_NAME}-${MINIFORGE_VERSION}-Linux-$(uname -m).sh -O /tmp/miniforge.sh && \
     /bin/bash /tmp/miniforge.sh -b -p ${CONDA_DIR} && \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update > /dev/null && \
         git > /dev/null && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    wget --no-hsts --quiet https://github.com/krallin/tini/releases/download/${TINI_VERSION}-$(cut -d / -f 2 <<< ${TARGETPLATFORM})/tini -O /usr/local/bin/tini && \
+    wget --no-hsts --quiet https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-$(cut -d / -f 2 <<< ${TARGETPLATFORM}) -O /usr/local/bin/tini && \
     chmod +x /usr/local/bin/tini && \
     wget --no-hsts --quiet https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/${MINIFORGE_NAME}-${MINIFORGE_VERSION}-Linux-$(uname -m).sh -O /tmp/miniforge.sh && \
     /bin/bash /tmp/miniforge.sh -b -p ${CONDA_DIR} && \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update > /dev/null && \
         git > /dev/null && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    wget --no-hsts --quiet https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -O /usr/local/bin/tini && \
+    wget --no-hsts --quiet https://github.com/krallin/tini/releases/download/${TINI_VERSION}-$(cut -d / -f 2 <<< ${TARGETPLATFORM})/tini -O /usr/local/bin/tini && \
     chmod +x /usr/local/bin/tini && \
     wget --no-hsts --quiet https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/${MINIFORGE_NAME}-${MINIFORGE_VERSION}-Linux-$(uname -m).sh -O /tmp/miniforge.sh && \
     /bin/bash /tmp/miniforge.sh -b -p ${CONDA_DIR} && \


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

When I run the `condaforge/miniforge3:4.9.2-5` image on an arm64v8 server, I get `standard_init_linux.go:211: exec user process caused "exec format error"` (which typically indicates an architecture mismatch). But if I don't use tini as the entrypoint, it seems to work. I'm pretty sure that this is because the tini binary is always the x86 default.

tini binaries - https://github.com/krallin/tini/releases

TARGETPLATFORM environment variable - https://docs.docker.com/buildx/working-with-buildx/

<!--
Please add any other relevant info below:
-->
I'm not sure whether any version number changes in the checklist are relevant here, so I'll wait for a response.