### PR TITLE
Install tini from Ubuntu's package repository

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:focal-20220922
 
 ARG MINIFORGE_NAME=Miniforge3
 ARG MINIFORGE_VERSION=4.14.0-0
-ARG TINI_VERSION=v0.18.0
 ARG TARGETPLATFORM
 
 ENV CONDA_DIR=/opt/conda
@@ -23,12 +22,11 @@ ENV PATH=${CONDA_DIR}/bin:${PATH}
 RUN apt-get update > /dev/null && \
     apt-get install --no-install-recommends --yes \
         wget bzip2 ca-certificates \
-        git > /dev/null && \
+        git \
+        tini \
+        > /dev/null && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    TARGETARCH="$(echo ${TARGETPLATFORM} | cut -d / -f 2)"; case ${TARGETARCH} in "ppc64le") TARGETARCH="ppc64el" ;; *) ;; esac ; \
-    wget --no-hsts --quiet https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} -O /usr/local/bin/tini && \
-    chmod +x /usr/local/bin/tini && \
     wget --no-hsts --quiet https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/${MINIFORGE_NAME}-${MINIFORGE_VERSION}-Linux-$(uname -m).sh -O /tmp/miniforge.sh && \
     /bin/bash /tmp/miniforge.sh -b -p ${CONDA_DIR} && \
     rm /tmp/miniforge.sh && \


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
`tini` version `0.18.0` is available from Ubuntu 20.04. We can use that one to simplify the build a little bit.

Furthermore, this then leaves `/usr/local` untouched and such that it isn't needed anymore for the entrypoint to work. That way one can use the image with bind mounting `/usr/local` as, e.g., is used in `mulled-build` from the Galaxy tools (which we use in our Bioconda build setup), see https://github.com/galaxyproject/galaxy/pull/14770#issuecomment-1280711217 .