### PR TITLE
Use ubuntu-latest to avoid deprecation brownouts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,11 @@ jobs:
     timeoutInMinutes: 360
     steps:
       - script: |
+          echo "Before:"
           cat /etc/docker/daemon.json
-          echo '{"experimental": true, "cgroup-parent": "/actions_job"}' | sudo tee /etc/docker/daemon.json
+          echo "Changing to:"
+          echo '{"experimental": true, "cgroup-parent": "/actions_job", "exec-opts": ["native.cgroupdriver=cgroupfs"]}' | sudo tee /etc/docker/daemon.json
+          echo "After:"
           cat /etc/docker/daemon.json
           sudo service docker restart
         displayName: Activate experimental Docker features

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ jobs:
     timeoutInMinutes: 360
     steps:
       - script: |
+          cat /etc/docker/daemon.json
           echo '{"experimental": true, "cgroup-parent": "/actions_job"}' | sudo tee /etc/docker/daemon.json
           cat /etc/docker/daemon.json
           sudo service docker restart

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: docker_build
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
     strategy:
       matrix:
         miniforge3:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,7 @@ jobs:
       - script: |
           echo "Before:"
           cat /etc/docker/daemon.json
-          echo "Changing to:"
-          echo '{"experimental": true, "cgroup-parent": "/actions_job", "exec-opts": ["native.cgroupdriver=cgroupfs"]}' | sudo tee /etc/docker/daemon.json
+          cat <<< $(jq '. + {"experimental": true}' /etc/docker/daemon.json) | sudo tee /etc/docker/daemon.json
           echo "After:"
           cat /etc/docker/daemon.json
           sudo service docker restart


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/11101. I _think_ that only applies to GHA, but tbh I don't see why we need 20.04 here anyway, so let's save some trouble in the future, just in case.